### PR TITLE
Integrate cds services with portal and ssr

### DIFF
--- a/app/portal/app/cds-api.ts
+++ b/app/portal/app/cds-api.ts
@@ -1,0 +1,100 @@
+import type { ConsentGrant } from "./grants.db";
+
+type CdsGrant = {
+  grant_id: string;
+  client_id?: string;
+  act?: string;
+  sub?: string;
+  sid?: string;
+  status?: string;
+  created_at?: string;
+  modified_at?: string;
+  expires_at?: string;
+  authorization_details?: Array<{
+    ID?: string;
+    type?: string;
+    actions?: string;
+    locations?: string;
+    toolName?: string;
+    toolDescription?: string;
+    riskLevel?: "low" | "medium" | "high";
+    category?: "file-system" | "data-access" | "system-admin" | "network" | "analytics" | string;
+  }>;
+  scope?: Array<{
+    ID?: string;
+    scope?: string;
+    resources?: string;
+  }>;
+};
+
+function toAbsolute(url: string, request: Request): string {
+  const base = new URL(request.url);
+  return new URL(url, base).toString();
+}
+
+function mapGrantFromCds(grant: CdsGrant): ConsentGrant {
+  const primaryScope = grant.scope?.[0]?.scope || "unknown";
+  const auth = grant.authorization_details || [];
+  const category = (auth[0]?.category as ConsentGrant["category"]) || "data-access";
+  const risk = (auth[0]?.riskLevel as ConsentGrant["riskLevel"]) || "low";
+  const description = auth[0]?.toolDescription || `Access for scope ${primaryScope}`;
+  const toolsIncluded: string[] = auth
+    .map((a) => a.toolName)
+    .filter((v): v is string => Boolean(v));
+
+  return {
+    id: grant.grant_id,
+    scope: primaryScope,
+    description,
+    granted: grant.status === "active",
+    grantedAt: grant.created_at,
+    expiresAt: grant.expires_at,
+    sessionId: grant.sid,
+    usage: 0,
+    lastUsed: undefined,
+    toolsIncluded: toolsIncluded.length ? toolsIncluded : [],
+    requester: undefined,
+    requesterId: undefined,
+    riskLevel: risk,
+    category,
+  };
+}
+
+export async function getGrants(request: Request): Promise<ConsentGrant[]> {
+  const res = await fetch(toAbsolute("/api/grants", request));
+  if (!res.ok) throw new Error(`Failed to load grants: ${res.status}`);
+  const data = (await res.json()) as CdsGrant[];
+  return data.map(mapGrantFromCds);
+}
+
+export async function getGrant(id: string, request: Request): Promise<ConsentGrant> {
+  const res = await fetch(toAbsolute(`/api/grants/${encodeURIComponent(id)}`, request));
+  if (res.status === 404) throw new Response("Not Found", { status: 404 });
+  if (!res.ok) throw new Error(`Failed to load grant ${id}: ${res.status}`);
+  const data = (await res.json()) as CdsGrant;
+  return mapGrantFromCds(data);
+}
+
+export async function updateGrant(
+  id: string,
+  payload: Partial<{
+    status: "active" | "inactive" | "revoked" | "expired";
+    expiresAt?: string | null;
+    sessionId?: string | null;
+  }>,
+  request: Request,
+) {
+  const body: Record<string, unknown> = {};
+  if (payload.status !== undefined) body.status = payload.status;
+  if (payload.expiresAt !== undefined) body.expires_at = payload.expiresAt;
+  if (payload.sessionId !== undefined) body.sid = payload.sessionId;
+
+  const res = await fetch(toAbsolute(`/api/grants/${encodeURIComponent(id)}`, request), {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`Failed to update grant ${id}: ${res.status}`);
+  return res.json();
+}
+

--- a/app/portal/app/routes/grants.$id.revoke.tsx
+++ b/app/portal/app/routes/grants.$id.revoke.tsx
@@ -10,6 +10,7 @@ import {
 import { Form, Link, redirect } from "react-router";
 import type { Route } from "./+types/grants.$id.revoke";
 import { grants } from "../grants.db";
+import { updateGrant } from "../cds-api";
 export { loader } from "./grants.$id._index";
 // Mock data - same as main consent route
 
@@ -23,12 +24,7 @@ export function meta({ params, data }: Route.MetaArgs) {
 export async function action({ request, params }: Route.ActionArgs) {
   const { id } = params;
   const formData = await request.formData();
-  const grant = grants.find((g) => g.id === id);
-  if (grant) {
-    grant.granted = false;
-    grant.revokedAt = new Date().toISOString();
-    grant.usage = 0;
-  }
+  await updateGrant(id as string, { status: "revoked" }, request);
 
   const grantUrl = new URL(request.url);
   grantUrl.pathname = grantUrl.pathname.replace(/\/grant$/, "");

--- a/app/portal/app/routes/grants.tsx
+++ b/app/portal/app/routes/grants.tsx
@@ -17,6 +17,7 @@ import { useActionData, useFetcher, Link, useLocation } from "react-router";
 import type { Route } from "./+types/grants";
 import type { ConsentGrant } from "../grants.db";
 import { generateConsentData } from "../grants.db";
+import { getGrants } from "../cds-api";
 
 // interface ConsentGrant {
 //   id: string;
@@ -48,14 +49,14 @@ export function meta({}: Route.MetaArgs) {
   ];
 }
 
-export function loader({ request }: Route.LoaderArgs) {
+export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
   const workloadFilter = url.searchParams.get("workload");
   const sessionFilter = url.searchParams.get("session");
 
-  let filteredGrants = currentConsentData.grants;
+  const allGrants = await getGrants(request);
 
-  // Apply workload filter
+  let filteredGrants = allGrants;
   if (workloadFilter) {
     const workloadSessionMap: Record<string, string> = {
       "wl-001": "S123",
@@ -65,17 +66,12 @@ export function loader({ request }: Route.LoaderArgs) {
     };
     const targetSession = workloadSessionMap[workloadFilter];
     if (targetSession) {
-      filteredGrants = currentConsentData.grants.filter(
-        (grant) => grant.sessionId === targetSession
-      );
+      filteredGrants = allGrants.filter((grant) => grant.sessionId === targetSession);
     }
   }
 
-  // Apply session filter
   if (sessionFilter) {
-    filteredGrants = currentConsentData.grants.filter(
-      (grant) => grant.sessionId === sessionFilter
-    );
+    filteredGrants = allGrants.filter((grant) => grant.sessionId === sessionFilter);
   }
 
   return {

--- a/srv/grant-management-service.js
+++ b/srv/grant-management-service.js
@@ -1,0 +1,29 @@
+import cds from "@sap/cds";
+
+class GrantManagementHandlers extends cds.ApplicationService {
+  async init() {
+    this.on("metadata", async () => {
+      return {
+        grant_management_actions_supported: [
+          "create",
+          "read",
+          "update",
+          "delete",
+          "revoke",
+        ],
+        grant_management_endpoint: "/api/grants",
+        grant_management_action_required: false,
+        server_info: {
+          name: "Grant Management Service",
+          version: cds?.version || "unknown",
+          supported_scopes: ["tools:read", "tools:write", "data:export"],
+        },
+      };
+    });
+
+    return super.init();
+  }
+}
+
+export default GrantManagementHandlers;
+


### PR DESCRIPTION
Integrate CAP CDS services into the portal and serve React Router SSR via the CAP server to replace mock data with live CDS data and unify the API and UI under one origin.

The portal now consumes data from CAP CDS services via REST endpoints, providing a real data source for grants management instead of in-memory mock data. The React Router SSR is embedded within the CAP server, allowing a single Express application to serve both the CDS API and the portal UI, simplifying deployment and enabling same-origin data fetching for SSR and client-side navigations.

---
<a href="https://cursor.com/background-agent?bcId=bc-67cb71f4-07c5-4e19-9b44-5b0c2e8b942a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-67cb71f4-07c5-4e19-9b44-5b0c2e8b942a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

