### PR TITLE
Flatten authorization details to permissions table

### DIFF
--- a/db/grants.cds
+++ b/db/grants.cds
@@ -254,3 +254,18 @@ aspect ApiAuthorizationDetailRequest {
 type RARClaim {
   essential: Boolean;
 }
+
+
+// Flattened view of authorization_details for analytics and policy checks
+// Holds key-value attributes per resource under a grant
+@cds.autoexpose :true
+entity Permissions: cuid, managed {
+  // Owning grant identifier (public string ID)
+  grant_id: String;
+  // Resource identifier (e.g., path, URL, db triplet, tool name)
+  resource_identifier: String;
+  // Attribute key (e.g., action, permission_read, protocol)
+  attribute: String;
+  // Attribute value normalized to string
+  value: String;
+}

--- a/srv/authorization-service/handler.requests.tsx
+++ b/srv/authorization-service/handler.requests.tsx
@@ -84,6 +84,13 @@ export default async function push(
     console.warn("⚠️ Failed to upsert authorization_details on request:", e);
   }
 
+  // Rebuild flattened permissions for the grant based on all current AuthorizationDetail records
+  try {
+    await rebuildPermissionsForGrant.call(this, grantId);
+  } catch (e) {
+    console.warn("⚠️ Failed to rebuild permissions:", e);
+  }
+
   return {
     request_uri: `urn:ietf:params:oauth:request_uri:${ID}`,
     expires_in: 90,
@@ -100,4 +107,103 @@ function parseAuthorizationDetails(authorization_details: string) {
         ...detail,
       };
     });
+}
+
+async function rebuildPermissionsForGrant(this: AuthorizationService, grantId: string) {
+  // 1) Read all AuthorizationDetail for the grant
+  const details: Array<Record<string, unknown>> = await this.run(
+    cds.ql.SELECT.from("com.sap.agent.grants.AuthorizationDetail").where({ grant_ID: grantId })
+  );
+
+  // 2) Compute flattened rows
+  const rows: Array<{ grant_id: string; resource_identifier: string; attribute: string; value: string }> = [];
+
+  for (const d of details) {
+    const type = String(d["type"] || "");
+    const identifier = String(d["identifier"] || "");
+
+    const actions = (Array.isArray(d["actions"]) ? (d["actions"] as unknown[]) : []).map(String);
+    const locations = (Array.isArray(d["locations"]) ? (d["locations"] as unknown[]) : []).map(String);
+    const roots = (Array.isArray((d as any)["roots"]) ? ((d as any)["roots"] as unknown[]) : []).map(String);
+    const urls = (Array.isArray((d as any)["urls"]) ? ((d as any)["urls"] as unknown[]) : []).map(String);
+    const protocols = (Array.isArray((d as any)["protocols"]) ? ((d as any)["protocols"] as unknown[]) : []).map(String);
+    const databases = (Array.isArray((d as any)["databases"]) ? ((d as any)["databases"] as unknown[]) : []).map(String);
+    const schemas = (Array.isArray((d as any)["schemas"]) ? ((d as any)["schemas"] as unknown[]) : []).map(String);
+    const tables = (Array.isArray((d as any)["tables"]) ? ((d as any)["tables"] as unknown[]) : []).map(String);
+    const server = (d as any)["server"] ? String((d as any)["server"]) : undefined;
+    const transport = (d as any)["transport"] ? String((d as any)["transport"]) : undefined;
+    const tools = (d as any)["tools"] && typeof (d as any)["tools"] === "object" ? ((d as any)["tools"] as Record<string, unknown>) : {};
+    const permissions = (d as any)["permissions"] && typeof (d as any)["permissions"] === "object" ? ((d as any)["permissions"] as Record<string, unknown>) : {};
+
+    // Resolve resource identifiers by type
+    const resourceIdentifiers: string[] = [];
+    if (type === "fs") {
+      if (locations.length > 0) resourceIdentifiers.push(...locations);
+      else if (roots.length > 0) resourceIdentifiers.push(...roots);
+    } else if (type === "api") {
+      if (urls.length > 0) resourceIdentifiers.push(...urls);
+    } else if (type === "mcp") {
+      if (server) resourceIdentifiers.push(server);
+    } else if (type === "database") {
+      const dbs = databases.length > 0 ? databases : [undefined];
+      const scs = schemas.length > 0 ? schemas : [undefined];
+      const tbs = tables.length > 0 ? tables : [undefined];
+      for (const db of dbs) {
+        for (const sc of scs) {
+          for (const tb of tbs) {
+            const parts = [db, sc, tb].filter(Boolean) as string[];
+            if (parts.length > 0) resourceIdentifiers.push(`db://${parts.join('/')}`);
+          }
+        }
+      }
+    }
+    if (resourceIdentifiers.length === 0) {
+      resourceIdentifiers.push(identifier || (type ? `type:${type}` : `grant:${grantId}`));
+    }
+
+    // Emit rows per resource identifier
+    for (const resId of resourceIdentifiers) {
+      // Always include type
+      rows.push({ grant_id: grantId, resource_identifier: resId, attribute: "type", value: type });
+
+      for (const a of actions) rows.push({ grant_id: grantId, resource_identifier: resId, attribute: "action", value: a });
+      for (const loc of locations) rows.push({ grant_id: grantId, resource_identifier: resId, attribute: "location", value: loc });
+      for (const rt of roots) rows.push({ grant_id: grantId, resource_identifier: resId, attribute: "root", value: rt });
+      for (const url of urls) rows.push({ grant_id: grantId, resource_identifier: resId, attribute: "url", value: url });
+      for (const proto of protocols) rows.push({ grant_id: grantId, resource_identifier: resId, attribute: "protocol", value: proto });
+
+      // Database attributes aligned with the identifier parts
+      if (resId.startsWith("db://")) {
+        const [, path] = resId.split("db://");
+        const parts = path.split("/");
+        if (parts[0]) rows.push({ grant_id: grantId, resource_identifier: resId, attribute: "database", value: parts[0] });
+        if (parts[1]) rows.push({ grant_id: grantId, resource_identifier: resId, attribute: "schema", value: parts[1] });
+        if (parts[2]) rows.push({ grant_id: grantId, resource_identifier: resId, attribute: "table", value: parts[2] });
+      }
+
+      // Tools map (truthy entries only)
+      for (const [toolName, granted] of Object.entries(tools)) {
+        if (granted) rows.push({ grant_id: grantId, resource_identifier: resId, attribute: "tool", value: toolName });
+      }
+
+      // FS permissions booleans
+      for (const [permKey, permVal] of Object.entries(permissions)) {
+        if (typeof permVal === "object" && permVal && "essential" in (permVal as any)) {
+          // RARClaim structure, treat presence as granted
+          rows.push({ grant_id: grantId, resource_identifier: resId, attribute: `permission_${permKey}`, value: "true" });
+        } else if (typeof permVal === "boolean") {
+          rows.push({ grant_id: grantId, resource_identifier: resId, attribute: `permission_${permKey}`, value: String(permVal) });
+        }
+      }
+
+      if (server) rows.push({ grant_id: grantId, resource_identifier: resId, attribute: "server", value: server });
+      if (transport) rows.push({ grant_id: grantId, resource_identifier: resId, attribute: "transport", value: transport });
+    }
+  }
+
+  // 3) Replace rows for this grant
+  await this.run(cds.ql.DELETE.from("com.sap.agent.grants.Permissions").where({ grant_id: grantId }));
+  if (rows.length > 0) {
+    await this.insert(rows).into("com.sap.agent.grants.Permissions");
+  }
 }

--- a/srv/grant-management.cds
+++ b/srv/grant-management.cds
@@ -38,6 +38,7 @@ service GrantsManagementService {
    
 
     entity AuthorizationDetail as projection on grants.AuthorizationDetail;
+    entity Permissions as projection on grants.Permissions;
 
     entity ConsentGrant as projection on grants.ConsentGrant; 
  


### PR DESCRIPTION
Flatten authorization details into a new `Permissions` table for easier analytics and policy checks.

The `Permissions` table provides a denormalized view of `AuthorizationDetail` records, making it simpler to query and evaluate specific permissions (`resource_identifier`, `grant_id`, `attribute`, `value`) without complex parsing of nested structures. This table is rebuilt on every upsert of `authorization_details` for a given grant.

---
<a href="https://cursor.com/background-agent?bcId=bc-6874aa94-0320-45a3-a614-02082b26be2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6874aa94-0320-45a3-a614-02082b26be2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

